### PR TITLE
Add File.GetLastWriteTimeUtc wrapper

### DIFF
--- a/System.Doubles/IO/FileSystemWrapper.cs
+++ b/System.Doubles/IO/FileSystemWrapper.cs
@@ -71,5 +71,10 @@
         {
             return File.Open(path, mode, access, share);
         }
+
+        public DateTime FileGetLastWriteTimeUtc(string path)
+        {
+            return File.GetLastWriteTimeUtc(path);
+        }
     }
 }

--- a/System.Doubles/IO/IFileSystem.cs
+++ b/System.Doubles/IO/IFileSystem.cs
@@ -29,5 +29,7 @@
         string FileReadAllText(string path);
 
         Stream FileOpen(string path, FileMode mode, FileAccess access, FileShare share);
+
+        DateTime FileGetLastWriteTimeUtc(string path);
     }
 }


### PR DESCRIPTION
@jameswelle @rjacobw Please review. File last write time is required by the 360 diagnostics page to match the behavior of Support's existing batch file to grab Articulate logs, which only includes files last modified in the past 7 days.