### PR TITLE
Add SetDataObject method to IClipboard

### DIFF
--- a/System.Doubles/Windows/ClipboardWrapper.cs
+++ b/System.Doubles/Windows/ClipboardWrapper.cs
@@ -6,5 +6,10 @@
         {
             Clipboard.SetText(text);
         }
+
+        public void SetDataObject(object data, bool copy)
+        {
+            Clipboard.SetDataObject(data, copy);
+        }
     }
 }

--- a/System.Doubles/Windows/IClipboard.cs
+++ b/System.Doubles/Windows/IClipboard.cs
@@ -3,5 +3,7 @@
     public interface IClipboard
     {
         void SetText(string text);
+
+        void SetDataObject(object data, bool copy);
     }
 }


### PR DESCRIPTION
@dbertram Please review. This is to work around [this issue](https://stackoverflow.com/questions/12769264/openclipboard-failed-when-copy-pasting-data-from-wpf-datagrid) where the `SetText` method throws an exception.