### PR TITLE
Add ETag to IHttpResponseHeaders

### DIFF
--- a/System.Doubles/Net/Http/HttpResponseHeadersWrapper.cs
+++ b/System.Doubles/Net/Http/HttpResponseHeadersWrapper.cs
@@ -4,6 +4,8 @@ namespace System.Net.Http
 {
     internal sealed class HttpResponseHeadersWrapper : IHttpResponseHeaders
     {
+        public EntityTagHeaderValue ETag => httpResponseHeaders.ETag;
+
         public Uri Location => httpResponseHeaders.Location;
 
         private readonly HttpResponseHeaders httpResponseHeaders;

--- a/System.Doubles/Net/Http/IHttpResponseHeaders.cs
+++ b/System.Doubles/Net/Http/IHttpResponseHeaders.cs
@@ -1,7 +1,14 @@
-﻿namespace System.Net.Http
+﻿using System.Net.Http.Headers;
+
+namespace System.Net.Http
 {
     public interface IHttpResponseHeaders
     {
+        EntityTagHeaderValue ETag
+        {
+            get;
+        }
+
         Uri Location
         {
             get;


### PR DESCRIPTION
@dbertram @jameswelle Please review. This is to support additional logging during downloads to debug invalid checksum errors.