### PR TITLE
Disable symbol publishing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ nuget:
   disable_publish_on_pr: true
 build:
   publish_nuget: true
-  publish_nuget_symbols: true
+  publish_nuget_symbols: false
   parallel: true
   verbosity: minimal
 artifacts:


### PR DESCRIPTION
An expired certificate on nuget.smbsrc.net is causing the build to fail trying to publish symbols; temporarily disable symbol publishing to work around it.